### PR TITLE
Hammer.js 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>hammerjs</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
     <name>HammerJS</name>
     <description>A javascript library for multi-touch gestures</description>
     <url>http://webjars.org</url>
@@ -41,9 +41,18 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hammer.version>1.0.5</hammer.version>
+        <hammer.version>1.1.3</hammer.version>
         <hammer.url>https://github.com/EightMedia/hammer.js/archive</hammer.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${hammer.version}</destDir>
+
+        <requirejs>
+            {
+                "paths": {
+                    "hammerjs": "hammer"
+                }
+            }
+        </requirejs>
+
     </properties>
 
     <build>
@@ -60,7 +69,7 @@
                         </goals>
                         <configuration>
                             <url>${hammer.url}</url>
-                            <fromFile>v${hammer.version}.zip</fromFile>
+                            <fromFile>${hammer.version}.zip</fromFile>
                             <toFile>${project.build.directory}/${project.artifactId}.zip</toFile>
                         </configuration>
                     </execution>
@@ -82,7 +91,10 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/hammer.js-${hammer.version}/dist" />
+                                    <filelist dir="${project.build.directory}/hammer.js-${hammer.version}">
+                                        <file name="hammer.js"/>
+                                        <file name="hammer.min.js"/>
+                                    </filelist>
                                 </move>
                             </target>
                         </configuration>
@@ -96,5 +108,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
- Upgrade to Hammer.js 1.1.3
- Use Require.js dependencies
